### PR TITLE
Find compatible engine image automatically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
+golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/cmd/arena/roms.go
+++ b/pkg/cmd/arena/roms.go
@@ -27,19 +27,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func findPython() string {
-	for _, name := range []string{
-		"python",
-		"python3",
-	} {
-		_, err := exec.LookPath(name)
-		if err == nil {
-			return name
-		}
-	}
-	return "python"
-}
-
 func NewScriptCmd(logger *log.Logger, name, script string, c *diambra.EnvConfig) *cobra.Command {
 	var pythonPath string
 	cmd := &cobra.Command{
@@ -62,12 +49,12 @@ func NewScriptCmd(logger *log.Logger, name, script string, c *diambra.EnvConfig)
 		},
 	}
 	c.AddRomsPathFlag(cmd.Flags())
-	cmd.Flags().StringVar(&pythonPath, "python", findPython(), "Path to python executable")
+	cmd.Flags().StringVar(&pythonPath, "python", pyarena.FindPython(), "Path to python executable")
 	return cmd
 }
 
 func NewRomCmds(logger *log.Logger) ([]*cobra.Command, error) {
-	c, err := diambra.NewConfig()
+	c, err := diambra.NewConfig(logger)
 	if err != nil {
 		level.Error(logger).Log("msg", err.Error())
 		os.Exit(1)

--- a/pkg/cmd/arena/up.go
+++ b/pkg/cmd/arena/up.go
@@ -30,7 +30,7 @@ import (
 )
 
 func NewUpCmd(logger *log.Logger) *cobra.Command {
-	c, err := diambra.NewConfig()
+	c, err := diambra.NewConfig(logger)
 	if err != nil {
 		level.Error(logger).Log("msg", err.Error())
 		os.Exit(1)

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -33,7 +33,7 @@ import (
 )
 
 func NewCmdRun(logger *log.Logger) *cobra.Command {
-	c, err := diambra.NewConfig()
+	c, err := diambra.NewConfig(logger)
 	if err != nil {
 		level.Error(logger).Log("msg", err.Error())
 		os.Exit(1)

--- a/pkg/pyarena/get_diambra_arena_version.py
+++ b/pkg/pyarena/get_diambra_arena_version.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+import pkg_resources
+
+print(pkg_resources.get_distribution("diambra-arena").version)

--- a/pkg/pyarena/pyarena.go
+++ b/pkg/pyarena/pyarena.go
@@ -17,6 +17,7 @@ package pyarena
 
 import (
 	_ "embed"
+	"os/exec"
 )
 
 //go:embed check_roms.py
@@ -24,3 +25,19 @@ var CheckRoms string
 
 //go:embed list_roms.py
 var ListRoms string
+
+//go:embed get_diambra_arena_version.py
+var GetDiambraArenaVersion string
+
+func FindPython() string {
+	for _, name := range []string{
+		"python",
+		"python3",
+	} {
+		_, err := exec.LookPath(name)
+		if err == nil {
+			return name
+		}
+	}
+	return "python"
+}


### PR DESCRIPTION
Assuming:

- diambra-arena version x.y.z is compatible with diambra-engine x.y.*
- diambra-engine always has a (moving) tag vx.y

This change will always use the engine image `diambra/engine:vx.y` for any diambra-arena version vx.y.*
We can 
