### PR TITLE
agent init: Generate without secrets by default

### DIFF
--- a/pkg/cmd/agent/init.go
+++ b/pkg/cmd/agent/init.go
@@ -45,6 +45,7 @@ func NewInitCmd(logger *log.Logger) *cobra.Command {
 		Args: cobra.ExactArgs(1),
 	}
 	cmd.Flags().StringVar(&config.Python.Version, "python.version", config.Python.Version, "Python version to use")
+	cmd.Flags().BoolVar(&config.Secret, "secret", config.Secret, "Include secret in agent")
 
 	return cmd
 }

--- a/pkg/cmd/agent/submit.go
+++ b/pkg/cmd/agent/submit.go
@@ -38,7 +38,7 @@ func NewSubmitCmd(logger *log.Logger) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "submit [--manifest submission-manifest.yaml | docker-image]",
+		Use:   "submit [--submission.manifest submission-manifest.yaml | docker-image]",
 		Short: "Submits an agent for evaluation",
 		Long:  `This takes a docker image or submission manifest and submits it for evaluation.`,
 		Args:  cobra.MaximumNArgs(1),

--- a/pkg/cmd/agent/test.go
+++ b/pkg/cmd/agent/test.go
@@ -28,7 +28,7 @@ func NewTestCmd(logger *log.Logger) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "test [--manifest submission-manifest.yaml | docker-image]",
+		Use:   "test [--submission.manifest submission-manifest.yaml | docker-image]",
 		Short: "Run an agent from image or manifest similar to how it would be evaluated",
 		Long: `This takes a docker image or submission manifest and runs it in the same way as it would be run when submitted
 		to DIAMBRA. This is useful for testing your agent before submitting it.`,

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -60,7 +60,7 @@ func NewDockerRunner(logger log.Logger, client *client.Client, autoRemove bool) 
 func (r *DockerRunner) Pull(c *Container, output *os.File) error {
 	reader, err := r.Client.ImagePull(context.TODO(), c.Image, types.ImagePullOptions{})
 	if err != nil {
-		return fmt.Errorf("couldn't pull image %s: %w:\nTo disable pulling the image on start, retry with --pull=false", c.Image, err)
+		return fmt.Errorf("couldn't pull image %s: %w:\nTo disable pulling the image on start, retry with --images.pull=false", c.Image, err)
 	}
 	defer reader.Close()
 

--- a/pkg/diambra/agents/README.md.tmpl
+++ b/pkg/diambra/agents/README.md.tmpl
@@ -4,31 +4,16 @@ This is a sample agent consisting of the following files:
 
 - [agent.py](agent.py) - The agent code
 - [requirements.txt](requirements.txt) - The dependencies for the agent
+{{ if .Secret }}
 - [Dockerfile](Dockerfile) - To build the image with all agent dependencies
+- [submission.yaml](submission.yaml) - The manifest including (secret) sources
+{{ else }}
+- [Dockerfile](Dockerfile) - To build the image with agent and all dependencies
+{{ end }}
 
-
-## Usage
-
-### Create public image with dependencies
-
-1. Edit `requirements.txt` to add your dependencies
-2. Build the image with `docker build -t registry/image .`
-  1. You can use any public registry for this, like [quay.io](quay.io) or [dockerhub](dockerhub.com)
-3. Push the image to the registry with `docker push registry/image`
-
-This image needs to be public so that it can be pulled by the DIAMBRA platform.
-
-### Create private agent and model
-1. Edit agent.py to add your code
-2. Train your agent
-3. Host your agent and model somewhere where it can be accessed by the DIAMBRA platform
-    1. You can use any service that provides the files via https, like [github](github.com),
-       [gitlab](gitlab.com) or [huggingface](huggingface.co)
-4. Edit [submission.yaml](submission.yaml) and:
-    1. Specify the image you created in the previous step
-    2. Add your agent and model urls, using {{`{{ .Secrets.<secret_name> }}`}} to reference secrets
-
-**DO NOT ADD SECRETS DIRECTLY TO THE MANIFEST. THEY WILL BE PUBLICLY VISIBLE.**
-
-### Submit agent
-Run `diambra agent submit --manifest submission.yaml -s <secret_name>=<secret_value>` to submit your agent.
+## Submit agent
+{{ if .Secret }}
+Run `diambra agent submit --submission.manifest submission.yaml --submission.secret <secret_name>=<secret_value>` to submit your agent.
+{{ else }}
+Run `diambra agent submit registy/image:tag` to submit your agent.
+{{ end }}

--- a/pkg/diambra/agents/dockerfile.tmpl
+++ b/pkg/diambra/agents/dockerfile.tmpl
@@ -7,3 +7,8 @@ RUN apt-get -qy update && \
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt
+
+{{ if not .Secret }}
+COPY . .
+ENTRYPOINT [ "python", "/app/agent.py" ]
+{{ end }}

--- a/pkg/diambra/agents/submission.yaml.tmpl
+++ b/pkg/diambra/agents/submission.yaml.tmpl
@@ -4,8 +4,7 @@ image: your/image:latest
 command:
 - python
 - "/sources/agent.py"
-- play
 - "/sources/model.zip"
 sources:
-  agent.py: https://ziemke:{{`{{.Secrets.token}}`}}@example.com/agent.py
-  model.zip: https://ziemke:{{`{{.Secrets.token}}`}}@example.com/model.zip
+  agent.py: https://username:{{`{{.Secrets.token}}`}}@example.com/agent.py
+  model.zip: https://username:{{`{{.Secrets.token}}`}}@example.com/model.zip


### PR DESCRIPTION
This closes #28

Without --secret:
```
agent init /tmp/foo
caller=generator.go:60 level=info msg="can't find local diambra-arena version, using latest" err="exit status 1"
caller=generator.go:66 level=debug msg="using diambra-arena version" version=2.1.0rc1
🖥️  Creating requirements.txt
🖥️  Creating agent.py
🖥️  Creating README.md
🖥️  Creating Dockerfile
🖥️  Agent initialized in /tmp/foo
```

Then if run with --secret it will show the diff and prompt to overwrite. I don't think automatically changing the files is reliably enough to not make it more confusing. I would expect users to either just overwrite the files, or skip them and do the changes manually. A nicer diff output would be great, especially the char-by-char diffs is confusing. I've filled #19 for that already but thats something for later.

Here is the current output:
![image](https://user-images.githubusercontent.com/275966/216774124-91ae9515-937b-4355-b160-51e72f60df6e.png)
