### PR TITLE
fix: Set XDG_RUNTIME_DIR

### DIFF
--- a/pkg/diambra/render.go
+++ b/pkg/diambra/render.go
@@ -30,6 +30,8 @@ func configureX11(config *EnvConfig, c *container.Container) error {
 	)
 	c.Hostname = config.Hostname
 	c.Env = append(c.Env, "DISPLAY="+os.Getenv("DISPLAY"))
+	c.Env = append(c.Env, "XDG_RUNTIME_DIR=/tmp/xdg") // avoid the XDG_RUNTIME_DIR error
+
 	c.IPCMode = "host" // We need to enable IPC to avoid "X Error:  BadShmSeg"
 	return nil
 }


### PR DESCRIPTION
This fixes the error on Linux Mint the error "`XDG_RUNTIME_DIR`  not set" when running with the `-g` flag 